### PR TITLE
Add basic Macy assistant prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 
 # Ada Library Information
 *.ali
+# Node modules
+node_modules/
+# Environment variables
+.env

--- a/README.md
+++ b/README.md
@@ -52,3 +52,4 @@ cd July4_Assignment_3
 npm install
 npm run dev
 
+```

--- a/index.js
+++ b/index.js
@@ -1,0 +1,50 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'GET') {
+    const filePath = path.join(__dirname, 'public', req.url === '/' ? 'index.html' : req.url);
+    fs.readFile(filePath, (err, content) => {
+      if (err) {
+        res.writeHead(404);
+        res.end('Not found');
+      } else {
+        const ext = path.extname(filePath).toLowerCase();
+        const typeMap = {
+          '.html': 'text/html',
+          '.js': 'text/javascript',
+          '.css': 'text/css'
+        };
+        const type = typeMap[ext] || 'text/plain';
+        res.writeHead(200, { 'Content-Type': type });
+        res.end(content);
+      }
+    });
+  } else if (req.method === 'POST' && req.url === '/api/chat') {
+    let body = '';
+    req.on('data', chunk => {
+      body += chunk;
+    });
+    req.on('end', () => {
+      try {
+        const data = JSON.parse(body);
+        const message = data.message || '';
+        const reply = `You said: ${message}`;
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ reply }));
+      } catch (err) {
+        res.writeHead(400);
+        res.end('Invalid JSON');
+      }
+    });
+  } else {
+    res.writeHead(404);
+    res.end('Not found');
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Server listening on http://localhost:${PORT}`);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "july4_assignment_3",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "july4_assignment_3",
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "july4_assignment_3",
+  "version": "1.0.0",
+  "description": "Welcome to Macy – a fun and interactive AI-powered coding assistant built to help beginners learn programming step by step. This pretend open-source project combines conversational AI with practical code walkthroughs for HTML, CSS, JavaScript, and Python.",
+  "main": "index.js",
+  "scripts": {
+    "dev": "node index.js",
+    "test": "node -e \"console.log('No tests specified')\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Macy - AI Coding Assistant</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1>Macy - AI Coding Assistant</h1>
+  <div id="chat"></div>
+  <textarea id="message" placeholder="Ask Macy something..."></textarea>
+  <button id="send">Send</button>
+
+  <h2>Code Preview</h2>
+  <textarea id="code" placeholder="Type HTML/CSS/JS code here..."></textarea>
+  <button id="preview">Preview</button>
+  <iframe id="preview-frame"></iframe>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,32 @@
+const chat = document.getElementById('chat');
+const messageInput = document.getElementById('message');
+const sendBtn = document.getElementById('send');
+const codeInput = document.getElementById('code');
+const previewBtn = document.getElementById('preview');
+const frame = document.getElementById('preview-frame');
+
+function addMessage(sender, text) {
+  const div = document.createElement('div');
+  div.className = sender;
+  div.textContent = text;
+  chat.appendChild(div);
+}
+
+sendBtn.addEventListener('click', async () => {
+  const message = messageInput.value.trim();
+  if (!message) return;
+  addMessage('user', message);
+  messageInput.value = '';
+  const res = await fetch('/api/chat', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ message })
+  });
+  const data = await res.json();
+  addMessage('bot', data.reply);
+});
+
+previewBtn.addEventListener('click', () => {
+  const code = codeInput.value;
+  frame.srcdoc = code;
+});

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,32 @@
+body {
+  font-family: Arial, sans-serif;
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+#chat {
+  border: 1px solid #ccc;
+  padding: 1rem;
+  min-height: 200px;
+  margin-bottom: 1rem;
+}
+
+#chat .user {
+  color: blue;
+}
+
+#chat .bot {
+  color: green;
+}
+
+textarea {
+  width: 100%;
+  margin-bottom: 0.5rem;
+}
+
+iframe {
+  width: 100%;
+  height: 200px;
+  border: 1px solid #ccc;
+}


### PR DESCRIPTION
## Summary
- scaffold Macy assistant with a minimal Node.js server
- add simple browser UI for chat and live code preview
- document installation steps and ignore node-specific files

## Testing
- `npm install`
- `npm test`
- `npm run dev` *(server started and was terminated with Ctrl+C)*

------
https://chatgpt.com/codex/tasks/task_e_689b551e5fd8832285a7c7597a1fc393